### PR TITLE
chore: bump lightning dependency to 0.0.113

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 bdk = "0.24"
-lightning = { version = "0.0.112", features = ["max_level_trace"] }
+lightning = { version = "0.0.113", features = ["max_level_trace"] }
 serde_json = "1.0.87"
 thiserror = "1"


### PR DESCRIPTION
This is needed for the new 10101 project which has already been upgraded to 0.0.113.